### PR TITLE
Extend profiling

### DIFF
--- a/html/rattle.js
+++ b/html/rattle.js
@@ -94,11 +94,13 @@ function unraw(xs) {
         name: x[0],
         execution: x[1],
         built: x[2],
-        filesWritten: x[3],
-        filesRead: x[4],
-        readers: x[5],
-        writers: x[6],
-        hazards: x[7] // depends and rdepends that violate consistency
+        builtLast: x[3],
+        changed: x[4],
+        filesWritten: x[5],
+        filesRead: x[6],
+        readers: x[7],
+        writers: x[8],
+        hazards: x[9] // depends and rdepends that violate consistency
     }));
     return ans;
 }
@@ -363,6 +365,9 @@ function showInt(x) {
 function showRun(run) {
     return run === 0 ? "Latest run" : run + " run" + plural(run) + " ago";
 }
+function showBool(b) {
+    return b === 1 ? "True" : "False";
+}
 function plural(n, not1 = "s", is1 = "") {
     return n === 1 ? is1 : not1;
 }
@@ -482,6 +487,15 @@ function createElement(type, props, ...children) {
 }
 // How .tsx gets desugared
 const React = { createElement };
+function showFile(p) {
+    if (p[1]) {
+        return React.createElement("li", null,
+            React.createElement("b", null, p[0]));
+    }
+    else {
+        return React.createElement("li", null, p[0]);
+    }
+}
 function reportDetails(profile, search) {
     const result = React.createElement("div", { class: "details" });
     const self = new Prop(0);
@@ -499,6 +513,14 @@ function reportDetails(profile, search) {
                 " ",
                 showRun(p.built)),
             React.createElement("li", null,
+                React.createElement("b", null, "Built last run:"),
+                " ",
+                showBool(p.builtLast)),
+            React.createElement("li", null,
+                React.createElement("b", null, "Changed:"),
+                " ",
+                showBool(p.changed)),
+            React.createElement("li", null,
                 React.createElement("b", null, "Execution time:"),
                 showTime(p.execution)),
             React.createElement("li", null,
@@ -511,11 +533,11 @@ function reportDetails(profile, search) {
                 React.createElement("b", null, "Cmds that I have a hazard with:"),
                 React.createElement("ul", null, p.hazards.map(d => React.createElement("li", null, f(d))))),
             React.createElement("li", null,
-                React.createElement("b", null, "Files I wrote:"),
-                React.createElement("ul", null, p.filesWritten.map(f => React.createElement("b", null, f)))),
+                React.createElement("b", null, "Files I wrote (bold files changed last run):"),
+                React.createElement("ul", null, p.filesWritten.map(f => showFile(f)))),
             React.createElement("li", null,
-                React.createElement("b", null, "Files I read:"),
-                React.createElement("ul", null, p.filesRead.map(f => React.createElement("b", null, f)))));
+                React.createElement("b", null, "Files I read (bold files changed last run):"),
+                React.createElement("ul", null, p.filesRead.map(f => showFile(f)))));
         $(result).empty().append(content);
     });
     return result;

--- a/html/ts/profile.tsx
+++ b/html/ts/profile.tsx
@@ -9,11 +9,13 @@ function unraw(xs: ProfileRaw[]): Profile[] {
         name: x[0],
         execution: x[1], // max time to build
         built: x[2], // number of times traced
-        filesWritten: x[3],
-        filesRead: x[4],
-        readers: x[5], // rdepends
-        writers: x[6], // depends
-        hazards: x[7] // depends and rdepends that violate consistency
+        builtLast: x[3], // was it built last run?
+        changed: x[4], // did any output files change during last build?
+        filesWritten: x[5],
+        filesRead: x[6],
+        readers: x[7], // rdepends
+        writers: x[8], // depends
+        hazards: x[9] // depends and rdepends that violate consistency
     } as Profile));
     return ans;
 }

--- a/html/ts/reports/details.tsx
+++ b/html/ts/reports/details.tsx
@@ -1,4 +1,12 @@
 
+function showFile(p: [string, int]): HTMLElement {
+    if (p[1] ) {
+        return <li><b>{p[0]}</b></li>;
+    } else {
+        return <li>{p[0]}</li>;
+    }
+}
+
 function reportDetails(profile: Profile[], search: Prop<Search>): HTMLElement {
     const result = <div class="details"></div>;
     const self: Prop<pindex> = new Prop(0);
@@ -9,6 +17,8 @@ function reportDetails(profile: Profile[], search: Prop<Search>): HTMLElement {
         const content = <ul>
             <li><b>Name:</b> {p.name}</li>
             <li><b>Built:</b> {showRun(p.built)}</li>
+            <li><b>Built last run:</b> {showBool(p.builtLast)}</li>
+            <li><b>Changed:</b> {showBool(p.changed)}</li>
             <li><b>Execution time:</b>{showTime(p.execution)}</li>
             <li><b>Cmds that wrote files I read:</b>
                 <ol>
@@ -25,14 +35,14 @@ function reportDetails(profile: Profile[], search: Prop<Search>): HTMLElement {
                     {p.hazards.map(d => <li>{f(d)}</li>)}
                 </ul>
             </li>
-            <li><b>Files I wrote:</b>
+            <li><b>Files I wrote (bold files changed last run):</b>
                 <ul>
-                    {p.filesWritten.map(f => <b>{f}</b>)}
+                    {p.filesWritten.map(f => showFile(f))}
                 </ul>
             </li>
-            <li><b>Files I read:</b>
+            <li><b>Files I read (bold files changed last run):</b>
                 <ul>
-                    {p.filesRead.map(f => <b>{f}</b>)}
+                    {p.filesRead.map(f => showFile(f))}
                 </ul>
             </li>
         </ul>;

--- a/html/ts/types.ts
+++ b/html/ts/types.ts
@@ -16,8 +16,10 @@ interface Profile {
     name: string; // Name of the thing I built
     execution: seconds; // Seconds I took to execute
     built: int; // number of times built
-    filesWritten: string[]; // files written
-    filesRead: string[]; // files read
+    builtLast: int; // was it built last run? 0 = no; 1 = yes
+    changed: int; // did some output change?
+    filesWritten: Array<[string, int]>; // files written
+    filesRead: Array<[string, int]>; // files read
     readers: pindex[]; // cmds that depend on me (aka they read file(s) i wrote)
     writers: pindex[]; // cmds I depend on (aka i read file(s) they wrote)
     hazards: pindex[]; // cmds that violate consistency with this cmd.
@@ -31,8 +33,10 @@ type ProfileRaw =
     [ string
     , seconds
     , int
-    , string[]
-    , string[]
+    , int
+    , int
+    , Array<[string, int]>
+    , Array<[string, int]>
     , pindex[]
     , pindex[]
     , pindex[]

--- a/html/ts/util.ts
+++ b/html/ts/util.ts
@@ -82,6 +82,10 @@ function showRun(run: timestamp): string {
     return run === 0 ? "Latest run" : run + " run" + plural(run) + " ago";
 }
 
+function showBool(b: int): string {
+    return b === 1 ? "True" : "False";
+}
+
 function plural(n: int, not1 = "s", is1 = ""): string {
     return n === 1 ? is1 : not1;
 }
@@ -209,7 +213,6 @@ Array.prototype.minimum = function<T>(this: number[], def?: number): number {
         res = Math.min(res, this[i]);
     return res;
 };
-
 
 // Use JSX with el instead of React.createElement
 // Originally from https://gist.github.com/sergiodxa/a493c98b7884128081bb9a281952ef33

--- a/src/Development/Rattle/Profile.hs
+++ b/src/Development/Rattle/Profile.hs
@@ -43,7 +43,7 @@ getCmdsTraces options@RattleOptions{..} = withShared rattleFiles$ \shared -> do
 
 getLastRun :: RattleOptions -> IO (Maybe T)
 getLastRun options@RattleOptions{..} = withShared rattleFiles $ \shared ->
-  lastRun shared rattleRun
+  lastRun shared rattleMachine
   
 constructGraph :: RattleOptions -> IO Graph
 constructGraph options@RattleOptions{..} = do

--- a/src/Development/Rattle/Server.hs
+++ b/src/Development/Rattle/Server.hs
@@ -33,7 +33,7 @@ import Control.Monad.IO.Class
 data RattleOptions = RattleOptions
     {rattleFiles :: FilePath -- ^ Where all my shared files go
     ,rattleSpeculate :: Maybe String -- ^ Should I speculate? Under which key?
-    ,rattleRun :: String -- ^ Key to store run# 
+    ,rattleMachine :: String -- ^ Key to store run# 
     ,rattleShare :: Bool -- ^ Should I share files from the cache
     ,rattleProcesses :: Int -- ^ Number of simulateous processes
     ,rattleCmdOptions :: [C.CmdOption] -- ^ Extra options added to every command line
@@ -101,7 +101,7 @@ withRattle :: RattleOptions -> (Rattle -> IO a) -> IO a
 withRattle options@RattleOptions{..} act = withShared rattleFiles $ \shared -> do
     speculate <- maybe (return []) (getSpeculate shared) rattleSpeculate
     speculate <- fmap (takeWhile (not . null . snd)) $ forM speculate $ \x -> (x,) <$> unsafeInterleaveIO (getCmdTraces shared x)
-    runNum <- nextRun shared rattleRun
+    runNum <- nextRun shared rattleMachine
     speculated <- newIORef False
     let s0 = Right $ S t0 Map.empty [] Map.empty [] []
     state <- newVar s0

--- a/src/Development/Rattle/Shared.hs
+++ b/src/Development/Rattle/Shared.hs
@@ -4,7 +4,8 @@ module Development.Rattle.Shared(
     Shared, withShared,
     getSpeculate, setSpeculate,
     getFile, setFile,
-    getCmdTraces, addCmdTrace
+    getCmdTraces, addCmdTrace,
+    nextRun, lastRun
     ) where
 
 import General.Extra
@@ -46,6 +47,21 @@ setList typ mode (Shared lock dir) name vals = withLock lock $ do
         hSetEncoding h utf8
         hPutStr h $ unlines $ map show vals
 
+nextRun :: Shared -> String -> IO T
+nextRun s n = do
+  ls <- getList "run" s n
+  case ls of
+    [] -> setRun t0 >> return t0
+    [t] -> let t1 = succ t in
+             setRun t1 >> return t1
+  where setRun t = setList "run" WriteMode s n [t]
+
+lastRun :: Shared -> String -> IO (Maybe T)
+lastRun s n = do
+  ls <- getList "run" s n
+  case ls of
+    [] -> return Nothing
+    [t] -> return $ Just t
 
 getSpeculate :: Shared -> String -> IO [Cmd]
 getSpeculate = getList "speculate"


### PR DESCRIPTION
Just extending the profiling so users can see which files changed between runs, whether a command was run in the latest run, and if the output files of the command changed since it last ran.  Doing this involved storing which run a trace came from. 