### PR TITLE
Introduce concept of restartable hazards. 

### DIFF
--- a/src/Development/Rattle/Profile.hs
+++ b/src/Development/Rattle/Profile.hs
@@ -84,7 +84,7 @@ createGraph xs = Graph xs $ g xs
 createEdge :: (Cmd,[Trace (FilePath, Hash)]) -> (Cmd,[Trace (FilePath, Hash)]) -> Maybe Edge
 createEdge p1@(cmd1,ts) p2@(cmd2,ls) = -- first look for write write hazard then look for both read/write and write/read hazards
   case writeWriteHazard ts ls of
-    Just fp -> Just $ Edge p1 p2 $ Just $ WriteWriteHazard fp cmd1 cmd2
+    Just fp -> Just $ Edge p1 p2 $ Just $ WriteWriteHazard fp cmd1 cmd2 NonRecoverable
     Nothing -> case readWriteHazard ts ls of
                  Just fp -> Just $ Edge p1 p2 $ Just $ ReadWriteHazard fp cmd1 cmd2 NonRecoverable
                  Nothing -> -- check for a non hazard edge

--- a/test/Test/Simple.hs
+++ b/test/Test/Simple.hs
@@ -53,7 +53,7 @@ main = unless isMac $ do
     withCurrentDirectory "inner" $
         rattleRun rattleOptions $ withCmdOptions [Cwd ".."]  build
     putStrLn "Build 7: Cause Restartable hazard"
-    rattleRun rattleOptions $ do
+    rattleRun rattleOptions $
       forM_ cs $ \c -> cmd "touch" c -- count as a write
     putStrLn "Should cause restartable hazard"
     rattleRun rattleOptions build

--- a/test/Test/Simple.hs
+++ b/test/Test/Simple.hs
@@ -52,3 +52,8 @@ main = unless isMac $ do
     createDirectoryIfMissing True "inner"
     withCurrentDirectory "inner" $
         rattleRun rattleOptions $ withCmdOptions [Cwd ".."]  build
+    putStrLn "Build 7: Cause Restartable hazard"
+    rattleRun rattleOptions $ do
+      forM_ cs $ \c -> cmd "touch" c -- count as a write
+    putStrLn "Should cause restartable hazard"
+    rattleRun rattleOptions build


### PR DESCRIPTION
Restartable hazards are hazards that might be avoided by not speculating outdated commands.

The logic in mergeFileOps is meant to match the logic in: https://github.com/ndmitchell/rattle/issues/13#issue-472486778

