### PR TITLE
expand directory names everywhere.

### DIFF
--- a/src/Development/Rattle/Server.hs
+++ b/src/Development/Rattle/Server.hs
@@ -113,7 +113,7 @@ withRattle options@RattleOptions{..} act = withUI rattleFancyUI (return "Running
     speculate <- maybe (return []) (getSpeculate shared) rattleSpeculate
     speculate <- fmap (takeWhile (not . null . snd)) $ -- don't speculate on things we have no traces for
         forM speculate $ \x ->
-            (x,) . map (fmap fst) <$> (unsafeInterleaveIO $ map (fmap $ first $ expand rattleNamedDirs) <$> (getCmdTraces shared x))
+            (x,) . map (fmap fst) <$> unsafeInterleaveIO (map (fmap $ first $ expand rattleNamedDirs) <$> getCmdTraces shared x)
     speculated <- newIORef False
 
     runNum <- nextRun shared rattleMachine

--- a/src/Development/Rattle/Server.hs
+++ b/src/Development/Rattle/Server.hs
@@ -113,7 +113,7 @@ withRattle options@RattleOptions{..} act = withUI rattleFancyUI (return "Running
     speculate <- maybe (return []) (getSpeculate shared) rattleSpeculate
     speculate <- fmap (takeWhile (not . null . snd)) $ -- don't speculate on things we have no traces for
         forM speculate $ \x ->
-            (x,) . map (fmap fst) <$> unsafeInterleaveIO (getCmdTraces shared x)
+            (x,) . map (fmap fst) <$> (unsafeInterleaveIO $ map (fmap $ first $ expand rattleNamedDirs) <$> (getCmdTraces shared x))
     speculated <- newIORef False
 
     runNum <- nextRun shared rattleMachine


### PR DESCRIPTION
I noticed some funky behavior with the simple tests where rattle was speculating commands that had obvious hazards.  It seems rattle wasn't comparing proper filenames and this should fix that by applying the name expansion code everywhere we grab traces.