### PR TITLE
decode ALL of the bytestring we read from the file. First thing in li…

### DIFF
--- a/src/Development/Rattle/Shared.hs
+++ b/src/Development/Rattle/Shared.hs
@@ -47,7 +47,7 @@ getList typ (Shared lock dir) name = withLock lock $ do
               | BS.null bstr = []
               | otherwise = case runGetState get bstr 0 of
                               Left str -> error $ "Failed to decode: " ++ str
-                              Right (a, rbstr) -> decodeAll rbstr ++ a
+                              Right (a, rbstr) -> a ++ decodeAll rbstr
 
 setList :: (Show a, Serialize b) => String -> IOMode -> Shared -> a -> [b] -> IO ()
 setList typ mode (Shared lock dir) name vals = withLock lock $ do
@@ -110,7 +110,7 @@ data File = File FileName ModTime Hash
 
 instance Serialize File
 
--- First trace in list should be most recent one.
+-- First trace in list is earliest one; last is latest one.
 getCmdTraces :: Shared -> Cmd -> IO [Trace (FileName, ModTime, Hash)]
 getCmdTraces shared cmd = map (fmap fromFile) <$> getList "command" shared cmd
     where fromFile (File path mt x) = (path, mt, x)

--- a/test/Test/Simple.hs
+++ b/test/Test/Simple.hs
@@ -30,7 +30,10 @@ main = unless isMac $ do
     putStrLn $ "Work: " ++ show w
     putStrLn $ "Span: " ++ show s
     putStrLn $ "Parallelism: " ++ show p
-    putStrLn "Build 2: Expect nothing"
+    putStrLn "Build 2: Expect 1 thing"
+    ignoreIO $ cmd ["sh", "-c", "echo '//comment' >> " ++ root </> "test/C/constants.c"]
+    rattleRun rattleOptions build
+    putStrLn "Build 2.5: Expect nothing"
     rattleRun rattleOptions build
     wipe
     putStrLn "Build 3: Expect cached (some speculation)"


### PR DESCRIPTION
A fix for a really bad bug.  Now the entire bytestring is decoded and errors are not ignored.  If there is a parsing error, the .rattle files probably just need to be deleted.  Also added a check to the simple test that exercises the bad behavior I was witnessing.