### PR TITLE
write to file

### DIFF
--- a/src/Development/Rattle/Options.hs
+++ b/src/Development/Rattle/Options.hs
@@ -29,12 +29,13 @@ data RattleOptions = RattleOptions
     ,rattleNamedDirs :: [(String, FilePath)] -- ^ Named directories, e.g. (PWD, .)
     ,rattleUI :: Maybe RattleUI -- ^ Nothing for auto detect
     ,rattleForward :: Bool -- ^ Support forward style stuff
+    ,rattleOut :: Maybe FilePath -- ^ File to write output to
     } deriving Show
 
 
 -- | Default 'RattleOptions' value.
 rattleOptions :: RattleOptions
-rattleOptions = RattleOptions ".rattle" (Just "") "m1" True 0 [] [("PWD",".")] Nothing False
+rattleOptions = RattleOptions ".rattle" (Just "") "m1" True 0 [] [("PWD",".")] Nothing False Nothing
 
 
 rattleOptionsExplicit :: RattleOptions -> IO RattleOptions


### PR DESCRIPTION
It seems too complicated right now to address, in fsatrace, the issue where 'out-file' is registered as a read if Rattle is run as follows:

haskell-program-that-runs-rattle &> out-file

So, I just added an option to write Rattle output to a file; which from my testing seems to avoid the problem for whatever reason.  I wasn't sure how to meld writing to a file with the RattleUI so I ignored that for now, but will do something with that after I hear your opinion.
